### PR TITLE
fix selector for elements using '__prefix__'

### DIFF
--- a/tinymce/static/django_tinymce/init_tinymce.js
+++ b/tinymce/static/django_tinymce/init_tinymce.js
@@ -29,7 +29,11 @@
         }
       });
 
-      if (!'selector' in mce_conf) {
+      // replace default prefix of 'empty-form' if used in selector
+      if (mce_conf.selector && mce_conf.selector.search(/__prefix__/) !== -1) {
+        mce_conf.selector = `#${el.id}`;
+      }
+      else if (!'selector' in mce_conf) {
         mce_conf['target'] = el;
       }
       if (el.dataset.mceGzConf) {


### PR DESCRIPTION
Widgets created from inlines may contain the default prefix '__prefix__' in the selector attribute. This change uses the element id instead to initialize TinyMCE.